### PR TITLE
Added a MarkUsed method

### DIFF
--- a/src/Treasure.Utils.Argument/Argument.cs
+++ b/src/Treasure.Utils.Argument/Argument.cs
@@ -9,6 +9,16 @@ using System.Runtime.CompilerServices;
 public static class Argument
 {
     /// <summary>
+    /// Marks the argument as being used.
+    /// This method is useful in situations where you need to implement an API,
+    /// but don't need a specific parameter and a discard won't work to please
+    /// an analyzer.
+    /// </summary>
+    public static void MarkUsed(object? _)
+    {
+    }
+
+    /// <summary>
     /// Asserts the value is not null and returns the value.
     /// </summary>
     /// <typeparam name="T"></typeparam>

--- a/test/Treasure.Utils.Argument.Tests/ArgumentTests.cs
+++ b/test/Treasure.Utils.Argument.Tests/ArgumentTests.cs
@@ -3,6 +3,20 @@ namespace Treasure.Utils.Tests;
 public class ArgumentTests
 {
     [Fact]
+    public void MarkUsed()
+    {
+        // Arrange
+        static void Method(string? useMe)
+        {
+            Argument.MarkUsed(useMe);
+        }
+        const string? value = null;
+
+        // Act
+        Method(value);
+    }
+
+    [Fact]
     public void NotNull()
     {
         // Arrange


### PR DESCRIPTION
Added an `Argument.MarkUsed` method, which is useful in situations where you need to implement an API, but don't need a specific parameter and a discard won't work to please an analyzer.