### PR TITLE
Change set-output and update Dependabot schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,9 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
-    time: '13:00'
+    day: 'friday'
+    time: '17:00'
+    timezone: 'America/Los_Angeles'
   open-pull-requests-limit: 10
   reviewers:
     - craigktreasure
@@ -15,7 +17,9 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
-    time: '13:00'
+    day: 'friday'
+    time: '17:00'
+    timezone: 'America/Los_Angeles'
   open-pull-requests-limit: 10
   reviewers:
     - craigktreasure

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           dotnet tool restore
           $packageVersion = dotnet nbgv get-version --variable NuGetPackageVersion
-          Write-Host "::set-output name=package_version::$packageVersion"
+          "package_version=$packageVersion" >> $env:GITHUB_OUTPUT
 
       - name: Install dependencies
         run: dotnet restore


### PR DESCRIPTION
- Replaced `set-output` with Environment Files as it's being [deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).
- Updated Dependabot schedule.