### PR TITLE
Fix build due to issues with the .NET SDK

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,8 +51,9 @@ jobs:
       - name: Install dependencies
         run: dotnet restore
 
-      - name: DotNet Format
-        run: dotnet format --no-restore --verify-no-changes
+      # Disable until https://github.com/dotnet/format/issues/1800 is fixed.
+      # - name: DotNet Format
+      #   run: dotnet format --no-restore --verify-no-changes
 
       - name: Build
         run: dotnet build --configuration Release --no-restore

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,7 +33,6 @@ jobs:
         with:
           dotnet-version: |
             6.x
-            7.0.100
             7.x
 
       - name: Patch global.json if necessary

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -26,7 +26,6 @@ jobs:
         with:
           dotnet-version: |
             6.x
-            7.0.100
             7.x
 
       - name: Patch global.json if necessary

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -36,8 +36,9 @@ jobs:
       - name: Install dependencies
         run: dotnet restore
 
-      - name: DotNet Format
-        run: dotnet format --no-restore --verify-no-changes
+      # Disable until https://github.com/dotnet/format/issues/1800 is fixed.
+      # - name: DotNet Format
+      #   run: dotnet format --no-restore --verify-no-changes
 
       - name: Build
         run: dotnet build --configuration Release --no-restore

--- a/scripts/PatchGlobalJson.ps1
+++ b/scripts/PatchGlobalJson.ps1
@@ -1,4 +1,4 @@
-if (-not $IsMacOS) {
+if ($true) {
     return
 }
 

--- a/src/Treasure.Utils.Argument/Argument.cs
+++ b/src/Treasure.Utils.Argument/Argument.cs
@@ -25,7 +25,7 @@ public static class Argument
     /// <param name="value">The value.</param>
     /// <param name="name">The argument name.</param>
     /// <returns>The value if not null.</returns>
-    public static T NotNull<T>([NotNull] T? value, [CallerArgumentExpression("value")] string name = "") where T : class
+    public static T NotNull<T>([NotNull] T? value, [CallerArgumentExpression(nameof(value))] string name = "") where T : class
     {
         if (value is null)
         {
@@ -41,7 +41,7 @@ public static class Argument
     /// <param name="value">The value.</param>
     /// <param name="name">The argument name.</param>
     /// <returns><see cref="string"/>.</returns>
-    public static string NotNullOrEmpty([NotNull] string? value, [CallerArgumentExpression("value")] string name = "")
+    public static string NotNullOrEmpty([NotNull] string? value, [CallerArgumentExpression(nameof(value))] string name = "")
     {
         if (value is null)
         {
@@ -62,7 +62,7 @@ public static class Argument
     /// <param name="value">The value.</param>
     /// <param name="name">The argument name.</param>
     /// <returns><see cref="string"/>.</returns>
-    public static string NotNullOrWhiteSpace([NotNull] string? value, [CallerArgumentExpression("value")] string name = "")
+    public static string NotNullOrWhiteSpace([NotNull] string? value, [CallerArgumentExpression(nameof(value))] string name = "")
     {
         if (value is null)
         {


### PR DESCRIPTION
- We previously used a PowerShell script to disable rollForward on macOS. Hoping this is no longer necessary with the updated 7.0.103 SDK.
- Disabled `dotnet format` until the issues in .NET SDK 7.0.200 are fixed.
- Fixed analyzer issues in recent .NET SDK.