### PR TITLE
Validate enumerations

### DIFF
--- a/Treasure.Utils.sln
+++ b/Treasure.Utils.sln
@@ -6,6 +6,11 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Treasure.Utils.Argument", "src\Treasure.Utils.Argument\Treasure.Utils.Argument.csproj", "{5F893AFE-E9C3-47AF-A872-95D1A9CD75FC}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{B012001D-4B86-460D-A3E1-FC3EEC840D13}"
+	ProjectSection(SolutionItems) = preProject
+		test\.editorconfig = test\.editorconfig
+		test\Directory.Build.props = test\Directory.Build.props
+		test\Directory.Packages.props = test\Directory.Packages.props
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Treasure.Utils.Argument.Tests", "test\Treasure.Utils.Argument.Tests\Treasure.Utils.Argument.Tests.csproj", "{EF141707-718F-49EC-99B9-8D7B59CBCCEF}"
 EndProject

--- a/src/Treasure.Utils.Argument/Argument.cs
+++ b/src/Treasure.Utils.Argument/Argument.cs
@@ -3,11 +3,32 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
+using Treasure.Utils.Extensions;
+
 /// <summary>
 /// A class containing various utilities useful for working with arguments.
 /// </summary>
 public static class Argument
 {
+    /// <summary>
+    /// Asserts the enumeration value is defined and returns the value.
+    /// Flag enumeration values are not asserted.
+    /// </summary>
+    /// <typeparam name="TEnum">The type of the enumeration.</typeparam>
+    /// <param name="value">The value.</param>
+    /// <param name="name">The argument name.</param>
+    /// <returns>The value.</returns>
+    public static TEnum IsDefined<TEnum>(TEnum value, [CallerArgumentExpression(nameof(value))] string name = "")
+        where TEnum : Enum
+    {
+        if (!value.IsFlagsEnum() && !value.IsDefined())
+        {
+            throw new ArgumentException($"The enumeration value is not defined: {value}.", name);
+        }
+
+        return value;
+    }
+
     /// <summary>
     /// Marks the argument as being used.
     /// This method is useful in situations where you need to implement an API,

--- a/src/Treasure.Utils.Argument/Extensions/EnumerationExtensions.cs
+++ b/src/Treasure.Utils.Argument/Extensions/EnumerationExtensions.cs
@@ -1,0 +1,28 @@
+﻿namespace Treasure.Utils.Extensions;
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+internal static class EnumerationExtensions
+{
+    private static readonly Dictionary<Type, bool> enumTypeFlagMap = new();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsDefined<TEnum>(this TEnum value)
+        where TEnum : Enum => Enum.IsDefined(typeof(TEnum), value);
+
+    public static bool IsFlagsEnum<TEnum>(this TEnum _)
+        where TEnum : Enum
+    {
+        Type enumType = typeof(TEnum);
+        if (enumTypeFlagMap.TryGetValue(enumType, out bool isFlagsEnum))
+        {
+            return isFlagsEnum;
+        }
+
+        isFlagsEnum = enumType.IsDefined(typeof(FlagsAttribute));
+        enumTypeFlagMap[enumType] = isFlagsEnum;
+
+        return isFlagsEnum;
+    }
+}

--- a/test/.editorconfig
+++ b/test/.editorconfig
@@ -1,0 +1,4 @@
+[*.cs]
+
+# CA1707: Identifiers should not contain underscores
+dotnet_diagnostic.CA1707.severity = none

--- a/test/Treasure.Utils.Argument.Tests/ArgumentTests.cs
+++ b/test/Treasure.Utils.Argument.Tests/ArgumentTests.cs
@@ -3,6 +3,36 @@
 public class ArgumentTests
 {
     [Fact]
+    public void IsDefined_FlagsEnum()
+    {
+        // Arrange
+        TestFlagsEnum value = TestFlagsEnum.One | TestFlagsEnum.Two;
+
+        // Act
+        Argument.IsDefined(value);
+        Argument.IsDefined(value);
+    }
+
+    [Fact]
+    public void IsDefined_StandardEnum()
+    {
+        // Arrange
+        TestStandardEnum value = TestStandardEnum.Value;
+
+        // Act
+        Argument.IsDefined(value);
+    }
+    [Fact]
+    public void IsDefined_StandardEnum_InvalidEnumThrows()
+    {
+        // Arrange
+        TestStandardEnum value = (TestStandardEnum)(-1);
+
+        // Act
+        Assert.Throws<ArgumentException>(nameof(value), () => Argument.IsDefined(value));
+    }
+
+    [Fact]
     public void MarkUsed()
     {
         // Arrange
@@ -83,5 +113,20 @@ public class ArgumentTests
 
         // Act and assert
         Assert.Throws<ArgumentNullException>(nameof(objectValue), () => Argument.NotNull(objectValue));
+    }
+
+    [Flags]
+    private enum TestFlagsEnum : short
+    {
+        None = 0,
+        One = 1,
+        Two = 2,
+        Four = 4,
+        Eight = 8
+    };
+
+    private enum TestStandardEnum : short
+    {
+        Value,
     }
 }


### PR DESCRIPTION
This change adds a new `Argument.IsDefined` method to assert that an enum value is defined. The one caveat is that flag enums are special and shouldn't necessarily need to be defined. The sad part is that the use of reflection appears to be the only way to determine if the enum has the `FlagsAttribute` applied. This comes at a bit of a cost, but I've attempted to minimize it by caching the reflection operation to determine if the enumeration has the `FlagsAttribute` applied. The big downside is that the use of reflection means the use of this library isn't trim safe.