### PR TITLE
Include LICENSE.txt in the .nupkg

### DIFF
--- a/src/Treasure.Utils.Argument/Treasure.Utils.Argument.csproj
+++ b/src/Treasure.Utils.Argument/Treasure.Utils.Argument.csproj
@@ -10,6 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="$(RepoRootPath)LICENSE.txt" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Nullable">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
I _think_ this is the Right Thing to do in order to fix #52.

I tried setting the `PackageLicenseFile` property in the `Treasure.Utils.Argument.csproj`, but the build was upset:

> NuGet.Build.Tasks.Pack.targets(221,5): error NU5033: Invalid metadata. Cannot specify both a PackageLicenseExpression and a PackageLicenseFile.

So I'm just adding `$(RepoRootPath)LICENSE.txt` as an `Item` and asking for it to be packed in the root of the package.