### PR TITLE
Enable GenerateDocumentationFile for tests projects

### DIFF
--- a/eng/DotNetDefaults.props
+++ b/eng/DotNetDefaults.props
@@ -31,7 +31,6 @@
 
     <!-- Generate XML documentation for not test projects. -->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <GenerateDocumentationFile Condition="$(MSBuildProjectName.EndsWith('.Tests'))">false</GenerateDocumentationFile>
 
     <!-- Normalize file paths on CI builds. -->
     <ContinuousIntegrationBuild>$(IsCIBuild)</ContinuousIntegrationBuild>

--- a/test/.editorconfig
+++ b/test/.editorconfig
@@ -1,0 +1,6 @@
+root = false
+
+[*.cs]
+
+# CS1591: Missing XML comment for publicly visible type or member
+dotnet_diagnostic.CS1591.severity = suggestion


### PR DESCRIPTION
The .NET 7.0 SDK 7.0.400+ added new requirements for some analyzers requiring `GenerateDocumentationFile`.