### PR TITLE
Performance improvements based on benchmarks

### DIFF
--- a/Treasure.Utils.sln
+++ b/Treasure.Utils.sln
@@ -28,6 +28,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{FDF5F72E
 		build\Defaults.targets = build\Defaults.targets
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Treasure.Utils.Argument.Benchmarks", "test\Treasure.Utils.Argument.Benchmarks\Treasure.Utils.Argument.Benchmarks.csproj", "{AB3B36BF-791F-4DC2-8B53-4BA812A80E86}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -42,6 +44,10 @@ Global
 		{EF141707-718F-49EC-99B9-8D7B59CBCCEF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EF141707-718F-49EC-99B9-8D7B59CBCCEF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EF141707-718F-49EC-99B9-8D7B59CBCCEF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AB3B36BF-791F-4DC2-8B53-4BA812A80E86}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AB3B36BF-791F-4DC2-8B53-4BA812A80E86}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AB3B36BF-791F-4DC2-8B53-4BA812A80E86}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AB3B36BF-791F-4DC2-8B53-4BA812A80E86}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -49,6 +55,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{EF141707-718F-49EC-99B9-8D7B59CBCCEF} = {B012001D-4B86-460D-A3E1-FC3EEC840D13}
 		{FDF5F72E-0C98-4976-8125-12C0ED9F89B4} = {A18B8F8E-8296-4968-A569-16F3F4FE045E}
+		{AB3B36BF-791F-4DC2-8B53-4BA812A80E86} = {B012001D-4B86-460D-A3E1-FC3EEC840D13}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {1304A800-AFA8-4EDF-9EBC-06F8680BADF1}

--- a/src/Treasure.Utils.Argument/Argument.cs
+++ b/src/Treasure.Utils.Argument/Argument.cs
@@ -27,10 +27,14 @@ public static class Argument
     /// <returns>The value if not null.</returns>
     public static T NotNull<T>([NotNull] T? value, [CallerArgumentExpression(nameof(value))] string name = "") where T : class
     {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(value, name);
+#else
         if (value is null)
         {
             throw new ArgumentNullException(name);
         }
+#endif
 
         return value;
     }
@@ -43,6 +47,9 @@ public static class Argument
     /// <returns><see cref="string"/>.</returns>
     public static string NotNullOrEmpty([NotNull] string? value, [CallerArgumentExpression(nameof(value))] string name = "")
     {
+#if NET7_0_OR_GREATER
+        ArgumentException.ThrowIfNullOrEmpty(value, name);
+#else
         if (value is null)
         {
             throw new ArgumentNullException(name);
@@ -52,6 +59,7 @@ public static class Argument
         {
             throw new ArgumentException("The value cannot be null or empty.", name);
         }
+#endif
 
         return value;
     }

--- a/src/Treasure.Utils.Argument/Argument.cs
+++ b/src/Treasure.Utils.Argument/Argument.cs
@@ -25,6 +25,7 @@ public static class Argument
     /// <param name="value">The value.</param>
     /// <param name="name">The argument name.</param>
     /// <returns>The value if not null.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static T NotNull<T>([NotNull] T? value, [CallerArgumentExpression(nameof(value))] string name = "") where T : class
     {
 #if NET6_0_OR_GREATER
@@ -45,6 +46,7 @@ public static class Argument
     /// <param name="value">The value.</param>
     /// <param name="name">The argument name.</param>
     /// <returns><see cref="string"/>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static string NotNullOrEmpty([NotNull] string? value, [CallerArgumentExpression(nameof(value))] string name = "")
     {
 #if NET7_0_OR_GREATER
@@ -70,6 +72,7 @@ public static class Argument
     /// <param name="value">The value.</param>
     /// <param name="name">The argument name.</param>
     /// <returns><see cref="string"/>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static string NotNullOrWhiteSpace([NotNull] string? value, [CallerArgumentExpression(nameof(value))] string name = "")
     {
         if (value is null)

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -3,6 +3,7 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Packages.props, $(MSBuildThisFileDirectory)..))" />
 
   <ItemGroup>
+    <PackageVersion Include="BenchmarkDotNet"                                   Version="0.13.8" />
     <PackageVersion Include="coverlet.collector"                                Version="6.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk"                            Version="17.7.2" />
     <PackageVersion Include="xunit"                                             Version="2.5.1" />

--- a/test/Treasure.Utils.Argument.Benchmarks/Program.cs
+++ b/test/Treasure.Utils.Argument.Benchmarks/Program.cs
@@ -1,0 +1,31 @@
+﻿// dotnet run -c Release -f net6.0 --filter "*" --runtimes net6.0 net7.0
+
+#pragma warning disable IDE0211
+#pragma warning disable CA1050
+#pragma warning disable CA1812
+#pragma warning disable CA1822
+#pragma warning disable CS1591
+
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
+
+using Treasure.Utils;
+
+BenchmarkSwitcher.FromAssembly(typeof(Tests).Assembly).Run(args);
+
+[HideColumns("value")]
+[DisassemblyDiagnoser]
+public class Tests
+{
+    [Benchmark]
+    [Arguments("foo")]
+    public void NotNull(string? value) => Argument.NotNull(value);
+
+    [Benchmark]
+    [Arguments("foo")]
+    public void NotNullOrEmpty(string? value) => Argument.NotNullOrEmpty(value);
+
+    [Benchmark]
+    [Arguments("foo")]
+    public void NotNullOrWhiteSpace(string? value) => Argument.NotNullOrWhiteSpace(value);
+}

--- a/test/Treasure.Utils.Argument.Benchmarks/Treasure.Utils.Argument.Benchmarks.csproj
+++ b/test/Treasure.Utils.Argument.Benchmarks/Treasure.Utils.Argument.Benchmarks.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
+    <RootNamespace>Treasure.Utils.Benchmarks</RootNamespace>
+    <IsTestProject>false</IsTestProject>
+
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Treasure.Utils.Argument\Treasure.Utils.Argument.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
While performing the .NET 8 upgrade, I decided to put together some benchmarks to help optimize the library a bit more. They seemed good enough to extract out to the current TFMs. After adding the benchmarks, I performed the following optimizations and measured:

- Per TFM optimizations to use new platform specific helpers.
- Add suggestions to inline the methods.

The original measurements based on the changes before the optimizations in this PR:

| Method              | Runtime  | Mean      | Ratio | Code Size |
|-------------------- |--------- |----------:|------:|----------:|
| NotNull             | .NET 6.0 | 0.0047 ns |     ? |      74 B |
| NotNull             | .NET 7.0 | 0.0281 ns |     ? |      75 B |
|                     |          |           |       |           |
| NotNullOrEmpty      | .NET 6.0 | 1.2290 ns |  1.00 |     159 B |
| NotNullOrEmpty      | .NET 7.0 | 1.2385 ns |  1.01 |     162 B |
|                     |          |           |       |           |
| NotNullOrWhiteSpace | .NET 6.0 | 2.7396 ns |  1.00 |     168 B |
| NotNullOrWhiteSpace | .NET 7.0 | 2.9706 ns |  1.08 |     172 B |

After performing the TFM optimizations:

| Method              | Runtime  | Mean      | Ratio | Code Size |
|-------------------- |--------- |----------:|------:|----------:|
| NotNull             | .NET 6.0 | 0.0121 ns |     ? |      43 B |
| NotNull             | .NET 7.0 | 0.0001 ns |     ? |      44 B |
|                     |          |           |       |           |
| NotNullOrEmpty      | .NET 6.0 | 1.2099 ns | 1.000 |     159 B |
| NotNullOrEmpty      | .NET 7.0 | 0.2334 ns | 0.193 |      58 B |
|                     |          |           |       |           |
| NotNullOrWhiteSpace | .NET 6.0 | 2.7246 ns |  1.00 |     168 B |
| NotNullOrWhiteSpace | .NET 7.0 | 2.9730 ns |  1.09 |     172 B |

This enabled .NET 7 to take advantage of some new platform APIs that now implement the same behavior to get a good speed boost on `NotNull` and `NotNullOrEmpty`.  The code complexity in `NotNullOrWhiteSpace` likely deterred inlining.

And then after adding the inline suggestions (includes TFM optimizations):

| Method              | Runtime  | Mean      | Ratio | Code Size |
|-------------------- |--------- |----------:|------:|----------:|
| NotNull             | .NET 6.0 | 0.0022 ns |     ? |      43 B |
| NotNull             | .NET 7.0 | 0.0000 ns |     ? |      44 B |
|                     |          |           |       |           |
| NotNullOrEmpty      | .NET 6.0 | 1.2180 ns | 1.000 |     159 B |
| NotNullOrEmpty      | .NET 7.0 | 0.2377 ns | 0.195 |      58 B |
|                     |          |           |       |           |
| NotNullOrWhiteSpace | .NET 6.0 | 2.7537 ns |  1.00 |     168 B |
| NotNullOrWhiteSpace | .NET 7.0 | 1.7353 ns |  0.63 |     285 B |

.NET 6 doesn't get a boost from the inlining suggestions, but .NET 7 did get a bit of a boost in the `NotNullOrWhiteSpace` method.

.NET 8 includes an implementation for `NotNullOrWhiteSpace`. While we don't get a speed boost, we do get a code size improvement.