### PR TITLE
Remove dependency-type from Dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,6 @@ updates:
     - craigktreasure
   groups:
     xunit:
-      dependency-type: "development"
       patterns:
       - "xunit*"
 


### PR DESCRIPTION
The grouping is not working. Trying to remove the `dependency-type` value to see if that fixes it.