### PR TITLE
Add test TFM for `netstandard2.1` TFM

### DIFF
--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -3,5 +3,11 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
+  <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+    <!-- Setup TFM properties for testing .NET Standard TFM's on supported platforms. -->
+    <PlatformTFMSuffix Condition="$([MSBuild]::IsOSPlatform('Windows'))">-windows</PlatformTFMSuffix>
+    <DefaultNetStandardTestTFM >net6.0$(PlatformTFMSuffix)</DefaultNetStandardTestTFM>
+  </PropertyGroup>
+
   <Import Project="$(MSBuildThisFileDirectory)/../Directory.Build.props" />
 </Project>

--- a/test/Treasure.Utils.Argument.Benchmarks/Treasure.Utils.Argument.Benchmarks.csproj
+++ b/test/Treasure.Utils.Argument.Benchmarks/Treasure.Utils.Argument.Benchmarks.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(TargetFrameworks);net7.0$(PlatformTFMSuffix);net6.0$(PlatformTFMSuffix)</TargetFrameworks>
     <RootNamespace>Treasure.Utils.Benchmarks</RootNamespace>
     <IsTestProject>false</IsTestProject>
 
@@ -16,6 +17,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Treasure.Utils.Argument\Treasure.Utils.Argument.csproj" />
+    <ProjectReference Update="..\..\src\Treasure.Utils.Argument\Treasure.Utils.Argument.csproj"
+                      Condition="$(TargetFramework.Contains($(PlatformTFMSuffix)))"
+                      SetTargetFramework="TargetFramework=netstandard2.1" />
   </ItemGroup>
 
 </Project>

--- a/test/Treasure.Utils.Argument.Tests/Treasure.Utils.Argument.Tests.csproj
+++ b/test/Treasure.Utils.Argument.Tests/Treasure.Utils.Argument.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(TargetFrameworks);$(DefaultNetStandardTestTFM)</TargetFrameworks>
     <RootNamespace>Treasure.Utils.Tests</RootNamespace>
 
     <IsPackable>false</IsPackable>
@@ -27,6 +28,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Treasure.Utils.Argument\Treasure.Utils.Argument.csproj" />
+    <ProjectReference Update="..\..\src\Treasure.Utils.Argument\Treasure.Utils.Argument.csproj"
+                      Condition="$(TargetFramework.Contains($(PlatformTFMSuffix)))"
+                      SetTargetFramework="TargetFramework=netstandard2.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Right now, tests are now executed for the `netstandard2.1` TFM of the library. This change adds an OS specific TFM to the test project specifically used to test the `netstandard2.1` TFM. The same technique was applied to the benchmarks.