### PR TITLE
Fix benchmark build errors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -229,3 +229,8 @@ csharp_style_unused_value_expression_statement_preference = discard_variable
 
 # IDE0059: Remove unnecessary value assignment
 csharp_style_unused_value_assignment_preference = discard_variable
+
+[*.notcs] # BenchmarkDotNet generated files
+
+# CS1591: Missing XML comment for publicly visible type or member
+dotnet_diagnostic.CS1591.severity = none


### PR DESCRIPTION
The benchmark project itself builds just fine. However, when you attempt to run the benchmarks, the BenchmarkDotNet generated code fails to adhere to my `.editorconfig` settings and then it throws errors. After more time than I care to admit fighting with it, I have landed on disabling the offending rule for `*.notcs` files.

```
[*.notcs] # BenchmarkDotNet generated files

# CS1591: Missing XML comment for publicly visible type or member
dotnet_diagnostic.CS1591.severity = none
```