### PR TITLE
Upgrade xunit and xunit.runner.visualstudio

### DIFF
--- a/src/Treasure.Utils.Argument/Treasure.Utils.Argument.csproj
+++ b/src/Treasure.Utils.Argument/Treasure.Utils.Argument.csproj
@@ -15,6 +15,11 @@
     <None Include="README.md" Pack="true" PackagePath="" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <!-- Enable AOT warnings. -->
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Nullable">
       <PrivateAssets>all</PrivateAssets>

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -7,8 +7,8 @@
     <PackageVersion Include="coverlet.collector"                                Version="6.0.0" />
     <PackageVersion Include="coverlet.msbuild"                                  Version="6.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk"                            Version="17.8.0" />
-    <PackageVersion Include="xunit"                                             Version="2.6.1" />
-    <PackageVersion Include="xunit.runner.visualstudio"                         Version="2.5.3" />
+    <PackageVersion Include="xunit"                                             Version="2.6.2" />
+    <PackageVersion Include="xunit.runner.visualstudio"                         Version="2.5.4" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This change upgrades `xunit` to `2.6.2` and `xunit.runner.visualstudio` to `2.5.4`.