### PR TITLE
Remove support for .NET 7

### DIFF
--- a/src/Treasure.Utils.Argument/Treasure.Utils.Argument.csproj
+++ b/src/Treasure.Utils.Argument/Treasure.Utils.Argument.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;netstandard2.1</TargetFrameworks>
     <RootNamespace>Treasure.Utils</RootNamespace>
 
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/test/Treasure.Utils.Argument.Benchmarks/Combine.ps1
+++ b/test/Treasure.Utils.Argument.Benchmarks/Combine.ps1
@@ -2,7 +2,7 @@
 
 [CmdletBinding()]
 Param (
-    [string[]] $TFMs = @('net6.0', 'net6.0-windows', 'net7.0', 'net7.0-windows', 'net8.0', 'net8.0-windows'),
+    [string[]] $TFMs = @('net6.0', 'net6.0-windows', 'net8.0', 'net8.0-windows'),
     [string[]] $Columns = @( 'Runtime', 'TFM', 'LibraryTfm', 'Method', 'Mean', 'Error', 'StdDev', 'Code Size'),
     [string] $ArtifactInputRoot = (Join-Path $PSScriptRoot '..' '..' '__benchmarks'),
     [string] $ResultOutputPath = (Join-Path $PSScriptRoot '..' '..' '__benchmarks' 'results.md'),
@@ -38,10 +38,6 @@ function BuildTableRowFromColumnsAndData ($columns, $data) {
 function GetLibraryTfmName ($tfm) {
     if ($tfm -eq 'net6.0') {
         return 'net6.0'
-    }
-
-    if ($tfm -eq 'net7.0') {
-        return 'net7.0'
     }
 
     if ($tfm -eq 'net8.0') {

--- a/test/Treasure.Utils.Argument.Benchmarks/Program.cs
+++ b/test/Treasure.Utils.Argument.Benchmarks/Program.cs
@@ -1,6 +1,6 @@
 ﻿// .\Run.ps1
 // or
-// dotnet run -c Release -f [net6.0 net7.0 net8.0] --filter "*"
+// dotnet run -c Release -f [net6.0 net8.0] --filter "*"
 
 #pragma warning disable CA1050
 #pragma warning disable CA1812

--- a/test/Treasure.Utils.Argument.Benchmarks/Run.ps1
+++ b/test/Treasure.Utils.Argument.Benchmarks/Run.ps1
@@ -2,7 +2,7 @@
 
 [CmdletBinding()]
 Param (
-    [string[]] $TFMs = @('net6.0', 'net6.0-windows', 'net7.0', 'net7.0-windows', 'net8.0', 'net8.0-windows'),
+    [string[]] $TFMs = @('net6.0', 'net6.0-windows', 'net8.0', 'net8.0-windows'),
     [string] $ArtifactOutputRoot = (Join-Path $PSScriptRoot '..' '..' '__benchmarks'),
     [string] $ResultOutputPath = (Join-Path $PSScriptRoot '..' '..' '__benchmarks' 'results.md')
 )

--- a/test/Treasure.Utils.Argument.Benchmarks/Treasure.Utils.Argument.Benchmarks.csproj
+++ b/test/Treasure.Utils.Argument.Benchmarks/Treasure.Utils.Argument.Benchmarks.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(TargetFrameworks);net8.0$(PlatformTFMSuffix);net7.0$(PlatformTFMSuffix);net6.0$(PlatformTFMSuffix)</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(TargetFrameworks);net8.0$(PlatformTFMSuffix);net6.0$(PlatformTFMSuffix)</TargetFrameworks>
     <RootNamespace>Treasure.Utils.Benchmarks</RootNamespace>
     <IsTestProject>false</IsTestProject>
 

--- a/test/Treasure.Utils.Argument.Tests/Treasure.Utils.Argument.Tests.csproj
+++ b/test/Treasure.Utils.Argument.Tests/Treasure.Utils.Argument.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(TargetFrameworks);$(DefaultNetStandardTestTFM)</TargetFrameworks>
     <RootNamespace>Treasure.Utils.Tests</RootNamespace>
   </PropertyGroup>

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.1",
+  "version": "2.0",
   "buildNumberOffset": -1,
   "nugetPackageVersion": {
     "semVer": 2


### PR DESCRIPTION
This change removes direct support for `net7.0` and changes the version number to `2.0`.